### PR TITLE
마이페이지 기능 구현, 코드 정리

### DIFF
--- a/src/components/common/BtnSubmit.tsx
+++ b/src/components/common/BtnSubmit.tsx
@@ -4,6 +4,7 @@ interface BtnSubmitProps {
   type?: "submit" | "reset" | "button" | undefined;
   value: string;
   onClick?: React.MouseEventHandler<HTMLButtonElement>;
+  dirty?: boolean;
 }
 
 const BtnSubmit: React.FC<BtnSubmitProps> = (props) => {
@@ -11,7 +12,9 @@ const BtnSubmit: React.FC<BtnSubmitProps> = (props) => {
     <button
       type={props.type}
       onClick={props.onClick}
-      className="w-full bg-MAIN_COLOR text-MAIN_IVORY h-14 rounded-lg text-lg mt-3"
+      className={`w-full bg-${
+        props.dirty === false ? "MAIN_GRAY" : "MAIN_COLOR"
+      } text-white h-14 rounded-lg text-lg mt-3`}
     >
       {props.value}
     </button>

--- a/src/components/common/BtnSubmit.tsx
+++ b/src/components/common/BtnSubmit.tsx
@@ -4,7 +4,7 @@ interface BtnSubmitProps {
   type?: "submit" | "reset" | "button" | undefined;
   value: string;
   onClick?: React.MouseEventHandler<HTMLButtonElement>;
-  dirty?: boolean;
+  active?: boolean;
 }
 
 const BtnSubmit: React.FC<BtnSubmitProps> = (props) => {
@@ -13,7 +13,7 @@ const BtnSubmit: React.FC<BtnSubmitProps> = (props) => {
       type={props.type}
       onClick={props.onClick}
       className={`w-full bg-${
-        props.dirty === false ? "MAIN_GRAY" : "MAIN_COLOR"
+        props.active === false ? "MAIN_GRAY" : "MAIN_COLOR"
       } text-white h-14 rounded-lg text-lg mt-3`}
     >
       {props.value}

--- a/src/components/common/CheckAvailabilityApi.tsx
+++ b/src/components/common/CheckAvailabilityApi.tsx
@@ -1,8 +1,12 @@
 import HttpClient from "../../utils/api/customAxios";
 
+import React from "react";
+
 const CheckAvailabilityApi = async (
   field: "loginId" | "nickName",
-  value: string
+  value: string,
+  setToastMessage: React.Dispatch<React.SetStateAction<string | null>>,
+  setDoubleCheck: React.Dispatch<React.SetStateAction<string>>
 ) => {
   let url = "";
 
@@ -14,10 +18,22 @@ const CheckAvailabilityApi = async (
   try {
     const response = await HttpClient.get(url);
     const message = response.data.message;
-    alert(message);
+    if (message?.includes("사용 가능한 닉네임 입니다")) {
+      setDoubleCheck("complete");
+    }
+    if (message?.includes("중복된 닉네임")) {
+      setDoubleCheck("duplicated");
+    }
+    setToastMessage(message);
+    setTimeout(() => {
+      setToastMessage(null);
+    }, 2000);
   } catch (error) {
-    alert("전송 오류!");
-    console.log(error)
+    console.log(error);
+    setToastMessage("오류가 발생했습니다");
+    setTimeout(() => {
+      setToastMessage(null);
+    }, 2000);
   }
 };
 export default CheckAvailabilityApi;

--- a/src/components/editprofile/EditProfileBtn.tsx
+++ b/src/components/editprofile/EditProfileBtn.tsx
@@ -9,7 +9,7 @@ const EditProfileBtn: React.FC<EditProfileBtnProps> = (props) => {
   return (
     <button
       type="button"
-      className="w-32 bg-MAIN_COLOR text-MAIN_IVORY ml-1 h-10 rounded-lg text-xs"
+      className="w-32 bg-MAIN_COLOR text-MAIN_IVORY ml-1 h-10 rounded-lg text-xs break-keep"
       onClick={props.onClick}
     >
       <div>{props.value}</div>

--- a/src/components/editprofile/EditProfileInput.tsx
+++ b/src/components/editprofile/EditProfileInput.tsx
@@ -12,7 +12,7 @@ const EditProfileInput: React.FC<EditProfileInputProps> = (props) => {
     <Field
       type={props.type}
       className={`p-2.5 border-2 h-10 w-full border-COMMONN_BORDER_GRAY appearance-none focus:border-MAIN_COLOR focus:outline-none focus:ring-transparent rounded-lg bg-${
-        props.disabled ? "gray-100" : undefined
+        props.disabled ? "MAIN_GRAY" : undefined
       }`}
       name={props.name}
       disabled={props.disabled}

--- a/src/components/mylikestore/MyLikeStoreCard.tsx
+++ b/src/components/mylikestore/MyLikeStoreCard.tsx
@@ -5,7 +5,6 @@ import { Avatar } from "flowbite-react";
 import { Link } from "react-router-dom";
 
 interface MyLikeStoreCardProps {
-  // likeNo: number;
   storeNo: number;
   storeImg: string;
   storeName: string;

--- a/src/components/mypage/MyPageMainBtn.tsx
+++ b/src/components/mypage/MyPageMainBtn.tsx
@@ -16,7 +16,7 @@ const MyPageMainBtn: React.FC<MyPageMainBtnProps> = (props) => {
       to={props.link}
       className="flex flex-col justify-center items-center border-2 border-solid border-MAIN_LIGHT_COLOR rounded-2xl w-1/2 h-40"
     >
-      <div className="flex justify-center items-center rounded-full bg-MAIN_GRAY p-4 w-28">
+      <div className="flex justify-center items-center rounded-full bg-MAIN_GRAY p-3 w-24">
         {props.title === "예약내역" && (
           <LuCalendarCheck2 color="#816F6B" size="72px" />
         )}

--- a/src/components/mypage/MyPagePetAdd.tsx
+++ b/src/components/mypage/MyPagePetAdd.tsx
@@ -12,7 +12,7 @@ const MyPagePetAdd: React.FC<MyPagePetAddProps> = (props) => {
       <div className="flex justify-start items-center px-5 py-3 gap-3">
         <Link
           to="/addmykkosoonae"
-          className="flex flex-col items-center border-2 border-dashed border-MAIN_LIGHT_COLOR rounded-full bg-MAIN_GRAY gap-2 px-6 py-3"
+          className="flex flex-col items-center border-2 border-dashed border-MAIN_LIGHT_COLOR rounded-full bg-MAIN_GRAY gap-2 px-6 py-3 sm:px-"
         >
           <PiPawPrintLight color="#816F6B" size="30px" />
           <div className="text-MAIN_LIGHT_COLOR text-xs text-center">

--- a/src/components/mypet/BtnMyPetGender.tsx
+++ b/src/components/mypet/BtnMyPetGender.tsx
@@ -1,5 +1,5 @@
-import { FormikProps } from "formik";
 import React from "react";
+import { FormikProps } from "formik";
 
 interface BtnMyPetGenderType {
   gender: string;

--- a/src/components/mypet/CustomDatePickerMyPet.tsx
+++ b/src/components/mypet/CustomDatePickerMyPet.tsx
@@ -1,6 +1,9 @@
 import React, { SyntheticEvent, forwardRef } from "react";
+
 import DatePicker from "react-datepicker";
+import "react-datepicker/dist/react-datepicker.css";
 import { ko } from "date-fns/locale";
+
 import { MYPET_FORM_LABEL } from "../../constants/constants";
 
 interface CustomDatePickerMyPetProps {

--- a/src/components/mypet/InputMyPet.tsx
+++ b/src/components/mypet/InputMyPet.tsx
@@ -1,5 +1,5 @@
-import { ErrorMessage, Field } from "formik";
 import React from "react";
+import { ErrorMessage, Field } from "formik";
 
 interface InputMyPetProps {
   name?: string;

--- a/src/components/mypet/SelectMyPetGender.tsx
+++ b/src/components/mypet/SelectMyPetGender.tsx
@@ -1,5 +1,7 @@
-import { FormikProps } from "formik";
 import React from "react";
+
+import { FormikProps } from "formik";
+
 import BtnMyPetGender from "./BtnMyPetGender";
 import { MYPET_FORM_LABEL } from "../../constants/constants";
 

--- a/src/components/myqna/MyQnACard.tsx
+++ b/src/components/myqna/MyQnACard.tsx
@@ -1,5 +1,4 @@
 import React from "react";
-
 interface MyQnACardProps {
   status: string;
   title: string;

--- a/src/components/myreservation/MyReservationCard.tsx
+++ b/src/components/myreservation/MyReservationCard.tsx
@@ -1,6 +1,8 @@
-import { Avatar } from "flowbite-react";
 import React from "react";
+
+import { Avatar } from "flowbite-react";
 import { Link } from "react-router-dom";
+
 import { PRICE_COMMA } from "../../constants/constants";
 
 interface MyReservationCardProps {

--- a/src/components/myreservation/MyReservationDetail.tsx
+++ b/src/components/myreservation/MyReservationDetail.tsx
@@ -2,16 +2,14 @@ import HttpClient from "../../utils/api/customAxios";
 
 import React, { useEffect, useState } from "react";
 import { useParams } from "react-router-dom";
-import { useNavigate } from "react-router-dom";
-import { reservationFormValues } from "../reservation/ReservationForm";
 
 import OuterLayout from "../common/OuterLayout";
 import PageTitle from "../common/PageTitle";
 import Nav from "../common/Nav";
 import ReservationCheckList from "../common/ReservationCheckList";
+import { reservationFormValues } from "../reservation/ReservationForm";
 
 const MyReservationDetail: React.FC = () => {
-  // const navigate = useNavigate();
   const { reservationNo } = useParams() as { reservationNo: string };
   const [myReservationDatas, setMyReservationDatas] =
     useState<reservationFormValues>(Object);

--- a/src/components/registerqna/RegisterQnAForm.tsx
+++ b/src/components/registerqna/RegisterQnAForm.tsx
@@ -1,9 +1,12 @@
-import React from "react";
-import { Link } from "react-router-dom";
-import RegisterQnAFormGroup from "./RegisterQnAFormGroup";
-import BtnSubmit from "../common/BtnSubmit";
-import { Form, Formik } from "formik";
 import HttpClient from "../../utils/api/customAxios";
+
+import React, { useState } from "react";
+import { Link } from "react-router-dom";
+import { Form, Formik } from "formik";
+
+import ToastMessage from "../common/ToastMessage";
+import BtnSubmit from "../common/BtnSubmit";
+import RegisterQnAFormGroup from "./RegisterQnAFormGroup";
 import { QnASchema } from "../../schema/formSchema";
 
 interface RegisterQnAFormProps {
@@ -16,13 +19,17 @@ interface QnAType {
 }
 
 const RegisterQnAForm: React.FC<RegisterQnAFormProps> = (props) => {
+  const [toastMessage, setToastMessage] = useState<string | null>(null);
   const handleFormSubmit = (values: QnAType) => {
     HttpClient.post("/KkoSoonNae/qna/create", values)
       .then((response) => {
         props.setStep(2);
       })
       .catch((error: any) => {
-        alert(error);
+        setToastMessage("오류가 발생했습니다");
+        setTimeout(() => {
+          setToastMessage(null);
+        }, 2000);
       });
   };
 
@@ -60,6 +67,7 @@ const RegisterQnAForm: React.FC<RegisterQnAFormProps> = (props) => {
             height={40}
           />
           <BtnSubmit type="submit" value="문의하기" />
+          {toastMessage && <ToastMessage message={toastMessage} />}
         </Form>
       </Formik>
     </div>

--- a/src/components/registerqna/RegisterQnAFormGroup.tsx
+++ b/src/components/registerqna/RegisterQnAFormGroup.tsx
@@ -1,5 +1,5 @@
-import { ErrorMessage, Field } from "formik";
 import React from "react";
+import { ErrorMessage, Field } from "formik";
 
 interface RegisterQnAFormGroupProps {
   label: string;

--- a/src/components/signup/SignUpPage.tsx
+++ b/src/components/signup/SignUpPage.tsx
@@ -12,6 +12,7 @@ const Main: React.FC = () => {
   const navigate = useNavigate();
   const [showPostcode, setShowPostcode] = useState(false);
   const [toastMessage, setToastMessage] = useState<string | null>(null);
+  const [doubleCheck, setDoubleCheck] = useState<string>("noProgress");
 
   return (
     <div className="flex flex-col justify-center items-center w-full h-full mt-2 font-bold text-sm">
@@ -40,22 +41,29 @@ const Main: React.FC = () => {
             address: values.address,
             addressDtl: values.addressDtl,
           };
-          HttpClient.post("/KkoSoonNae/customer/signUp", payload)
-            .then((response) => {
-              setToastMessage("회원가입이 완료되었습니다!");
-              const res = response.data;
-              console.log(res);
-              setTimeout(() => {
-                navigate("/");
-              }, 800);
-            })
-            .catch((error) => {
-              setTimeout(() => {
-                setToastMessage(error.response.data.message);
-              }, 800);
-            });
-          alert(JSON.stringify(values, null, 2));
-          setSubmitting(false);
+          if (doubleCheck === "noProgress") {
+            setToastMessage("닉네임 중복확인을 진행해주세요");
+            setTimeout(() => {
+              setToastMessage(null);
+            }, 1000);
+          } else if (doubleCheck === "complete") {
+            HttpClient.post("/KkoSoonNae/customer/signUp", payload)
+              .then((response) => {
+                setToastMessage("회원가입이 완료되었습니다!");
+                const res = response.data;
+                console.log(res);
+                setTimeout(() => {
+                  navigate("/");
+                }, 800);
+              })
+              .catch((error) => {
+                setTimeout(() => {
+                  setToastMessage(error.response.data.message);
+                }, 800);
+              });
+            alert(JSON.stringify(values, null, 2));
+            setSubmitting(false);
+          }
         }}
       >
         {({ setFieldValue, values }) => (
@@ -75,12 +83,15 @@ const Main: React.FC = () => {
                   {["loginId", "nickName"].includes(field.name) && (
                     <button
                       type="button"
-                      onClick={() =>
+                      onClick={() => {
+                        setToastMessage(null);
                         CheckAvailabilityApi(
                           field.name as "loginId" | "nickName",
-                          values[field.name as "loginId" | "nickName"]
-                        )
-                      }
+                          values[field.name as "loginId" | "nickName"],
+                          setToastMessage,
+                          setDoubleCheck
+                        );
+                      }}
                       className="rounded-lg border-2 border-solid border-main-light-color text-xs w-16 h-10 mt-2 ml-1"
                     >
                       중복확인

--- a/src/page/AddMyPet.tsx
+++ b/src/page/AddMyPet.tsx
@@ -52,7 +52,10 @@ const AddMyPet: React.FC = () => {
           }, 1000);
         })
         .catch((error: any) => {
-          alert(error);
+          setToastMessage("오류가 발생했습니다");
+          setTimeout(() => {
+            setToastMessage(null);
+          }, 1000);
         });
     } else {
       setToastMessage("반려동물의 이미지를 넣어주세요");
@@ -60,6 +63,15 @@ const AddMyPet: React.FC = () => {
         setToastMessage(null);
       }, 3000);
       return;
+    }
+  };
+
+  const handleFormIsValid = (isValid: boolean) => {
+    if (!isValid) {
+      setToastMessage("반려동물의 정보를 올바르게 작성해주세요");
+      setTimeout(() => {
+        setToastMessage(null);
+      }, 1000);
     }
   };
 
@@ -81,7 +93,7 @@ const AddMyPet: React.FC = () => {
         validationSchema={EditMyPetSchema}
         enableReinitialize={true}
       >
-        {({ setFieldValue, values }) => (
+        {({ setFieldValue, values, isValid, dirty }) => (
           <Form className="pt-4 pb-24 px-4 font-bold">
             <ImgMyPet
               img={values.petImg}
@@ -112,7 +124,14 @@ const AddMyPet: React.FC = () => {
               placeholder="내 꼬순내 몸무게를 입력해주세요."
               label={MYPET_FORM_LABEL.weight}
             />
-            <BtnSubmit value="등록하기" type="submit" />
+            <BtnSubmit
+              value="수정하기"
+              type={isValid === true ? "submit" : "button"}
+              active={isValid}
+              onClick={() => {
+                handleFormIsValid(isValid);
+              }}
+            />
             {toastMessage && <ToastMessage message={toastMessage} />}
           </Form>
         )}

--- a/src/page/EditMyPet.tsx
+++ b/src/page/EditMyPet.tsx
@@ -1,22 +1,21 @@
 import HttpClient from "../utils/api/customAxios";
 
 import React, { useEffect, useState } from "react";
+import { Form, Formik } from "formik";
+import { EditMyPetSchema } from "../schema/formSchema";
+import { useParams } from "react-router-dom";
+
 import OuterLayout from "../components/common/OuterLayout";
 import PageTitle from "../components/common/PageTitle";
 import Nav from "../components/common/Nav";
 import BtnSubmit from "../components/common/BtnSubmit";
 import ImgMyPet from "../components/mypet/ImgMyPet";
 import InputMyPet from "../components/mypet/InputMyPet";
-
-import { Form, Formik } from "formik";
-import { EditMyPetSchema } from "../schema/formSchema";
-import { useParams } from "react-router-dom";
-import "react-datepicker/dist/react-datepicker.css";
 import CustomDatePickerMyPet from "../components/mypet/CustomDatePickerMyPet";
-import { MYPET_FORM_LABEL } from "../constants/constants";
 import SelectMyPetGender from "../components/mypet/SelectMyPetGender";
 import ModalDelete from "../components/common/ModalDelete";
 import ToastMessage from "../components/common/ToastMessage";
+import { MYPET_FORM_LABEL } from "../constants/constants";
 
 interface MyPetInfosType {
   name: string;
@@ -64,18 +63,21 @@ const EditMyPet: React.FC = () => {
       )
         .then((response) => {
           setToastMessage(`${values.name}의 정보가 수정되었습니다`);
-          setTimeout(function () {
+          setTimeout(() => {
             window.location.href = "/mypage";
           }, 1000);
         })
         .catch((error: any) => {
-          alert(error);
+          setToastMessage("오류가 발생했습니다");
+          setTimeout(() => {
+            setToastMessage(null);
+          }, 1000);
         });
     } else {
       setToastMessage("반려동물의 이미지를 넣어주세요");
-      setTimeout(function () {
+      setTimeout(() => {
         setToastMessage(null);
-      }, 3000);
+      }, 1000);
       return;
     }
   };
@@ -88,27 +90,39 @@ const EditMyPet: React.FC = () => {
     setShowModalDelete(true);
   };
 
+  const handleFormNotChange = (dirty: boolean) => {
+    if (!dirty) {
+      setToastMessage("반려동물의 정보를 수정해주세요");
+      setTimeout(() => {
+        setToastMessage(null);
+      }, 1000);
+    }
+  };
+
   const deleteMyPetDatas = async (petNo: number, petName: string) => {
     await HttpClient.delete(`/KkoSoonNae/pet/deletePet/${petNo}`)
       .then((response) => {
-        if (response.data.message == "해당 반려동물은 현재 예약 상태입니다.") {
+        if (response.data.message === "해당 반려동물은 현재 예약 상태입니다.") {
           setShowModalDelete(false);
           setToastMessage(
             `${petName}은 미용이 예약되어 있어 삭제할 수 없습니다`
           );
-          setTimeout(function () {
+          setTimeout(() => {
             setToastMessage(null);
-          }, 3000);
+          }, 1000);
         } else {
           setShowModalDelete(false);
           setToastMessage(`${petName}의 정보가 삭제되었습니다`);
-          setTimeout(function () {
-            window.location.href = "/mypage";
+          setTimeout(() => {
+            setToastMessage(null);
           }, 1000);
         }
       })
       .catch((error: any) => {
-        alert(error);
+        setToastMessage("오류가 발생했습니다");
+        setTimeout(() => {
+          setToastMessage(null);
+        }, 1000);
       });
   };
 
@@ -144,7 +158,7 @@ const EditMyPet: React.FC = () => {
         validationSchema={EditMyPetSchema}
         enableReinitialize={true}
       >
-        {({ setFieldValue, values }) => (
+        {({ setFieldValue, values, dirty }) => (
           <Form className="pt-4 pb-24 px-4 font-bold">
             <ImgMyPet
               img={values.petImg}
@@ -163,7 +177,14 @@ const EditMyPet: React.FC = () => {
               setFieldValue={setFieldValue}
             />
             <InputMyPet name="weight" label={MYPET_FORM_LABEL.weight} />
-            <BtnSubmit value="수정하기" type="submit" />
+            <BtnSubmit
+              value="수정하기"
+              type={dirty === true ? "submit" : "button"}
+              active={dirty}
+              onClick={() => {
+                handleFormNotChange(dirty);
+              }}
+            />
             <button
               type="button"
               className="w-full text-right mt-3 underline text-gray-400"

--- a/src/page/EditProfile.tsx
+++ b/src/page/EditProfile.tsx
@@ -171,7 +171,7 @@ const EditProfile: React.FC = () => {
               <BtnSubmit
                 value="수정하기"
                 type={dirty === true ? "submit" : "button"}
-                dirty={dirty}
+                active={dirty}
                 onClick={() => {
                   handleFormNotChange(dirty);
                 }}

--- a/src/page/EditProfile.tsx
+++ b/src/page/EditProfile.tsx
@@ -13,6 +13,7 @@ import EditProfileInput from "../components/editprofile/EditProfileInput";
 import EditProfileFormGroup from "../components/editprofile/EditProfileFormGroup";
 import EditProfileErrorMsg from "../components/editprofile/EditProfileErrorMsg";
 import CheckAvailabilityApi from "../components/common/CheckAvailabilityApi";
+import ToastMessage from "../components/common/ToastMessage";
 
 interface MyProfileType {
   nickName: string;
@@ -24,6 +25,9 @@ interface MyProfileType {
 
 const EditProfile: React.FC = () => {
   const [showPostcode, setShowPostcode] = useState<boolean>(false);
+  const [toastMessage, setToastMessage] = useState<string | null>(null);
+  const [doubleCheck, setDoubleCheck] = useState<string>("noProgress");
+  const [userNinkName, setUserNinkName] = useState<string | null>(null);
   const [myProfileInfos, setMyProfileInfos] = useState<MyProfileType>({
     nickName: "",
     phone: "",
@@ -37,14 +41,56 @@ const EditProfile: React.FC = () => {
   };
 
   const handleFormSubmit = (values: MyProfileType) => {
-    HttpClient.put("/KkoSoonNae/customer/profile/update", values)
-      .then((response) => {
-        alert("프로필 수정 성공하였습니다");
-        window.location.href = "/mypage";
-      })
-      .catch((error: any) => {
-        alert(error);
-      });
+    if (values.nickName !== userNinkName && doubleCheck === "noProgress") {
+      setToastMessage("닉네임 중복확인을 진행해주세요");
+      setTimeout(() => {
+        setToastMessage(null);
+      }, 1000);
+    } else if (doubleCheck === "duplicated") {
+      setToastMessage("이미 사용 중인 닉네임으로 수정할 수 없습니다");
+      setTimeout(() => {
+        setToastMessage(null);
+      }, 1000);
+    } else {
+      HttpClient.put("/KkoSoonNae/customer/profile/update", values)
+        .then(() => {
+          setToastMessage("프로필 수정을 성공하였습니다");
+          setTimeout(() => {
+            window.location.href = "/mypage";
+          }, 1000);
+        })
+        .catch((error: any) => {
+          setToastMessage(error);
+          setTimeout(() => {
+            setToastMessage(null);
+          }, 1000);
+        });
+    }
+  };
+
+  const handleFormNotChange = (dirty: boolean) => {
+    if (!dirty) {
+      setToastMessage("프로필을 수정해주세요");
+      setTimeout(() => {
+        setToastMessage(null);
+      }, 1000);
+    }
+  };
+
+  const handlerNickNameDoubleCheck = async (nickName: string) => {
+    if (nickName === userNinkName) {
+      setToastMessage("현재 사용 중인 닉네임입니다");
+      setTimeout(() => {
+        setToastMessage(null);
+      }, 1000);
+    } else {
+      await CheckAvailabilityApi(
+        "nickName",
+        nickName,
+        setToastMessage,
+        setDoubleCheck
+      );
+    }
   };
 
   const getMyProfile = async (): Promise<MyProfileType> => {
@@ -56,6 +102,7 @@ const EditProfile: React.FC = () => {
     const fetchProfile = async () => {
       const profileData = await getMyProfile();
       setMyProfileInfos(profileData);
+      setUserNinkName(profileData.nickName);
     };
 
     fetchProfile();
@@ -73,7 +120,7 @@ const EditProfile: React.FC = () => {
           validationSchema={EditProfileSchema}
           enableReinitialize={true}
         >
-          {({ setFieldValue, values }) => (
+          {({ setFieldValue, values, dirty }) => (
             <Form className="flex flex-col gap-3 w-full">
               <EditProfileFormGroup
                 label="닉네임"
@@ -81,7 +128,10 @@ const EditProfile: React.FC = () => {
                 name="nickName"
                 inputDisabled={false}
                 btnActive={true}
-                btnValue="중복체크"
+                btnValue="중복확인"
+                onClick={() => {
+                  handlerNickNameDoubleCheck(values.nickName);
+                }}
               />
               <EditProfileFormGroup
                 label="전화번호"
@@ -118,7 +168,15 @@ const EditProfile: React.FC = () => {
                 />
                 <EditProfileErrorMsg name="addressDtl" />
               </div>
-              <BtnSubmit value="수정하기" type="submit" />
+              <BtnSubmit
+                value="수정하기"
+                type={dirty === true ? "submit" : "button"}
+                dirty={dirty}
+                onClick={() => {
+                  handleFormNotChange(dirty);
+                }}
+              />
+              {toastMessage && <ToastMessage message={toastMessage} />}
             </Form>
           )}
         </Formik>

--- a/src/page/MyLikeStore.tsx
+++ b/src/page/MyLikeStore.tsx
@@ -1,9 +1,11 @@
+import HttpClient from "../utils/api/customAxios";
+
 import React, { useEffect, useState } from "react";
+
 import OuterLayout from "../components/common/OuterLayout";
 import PageTitle from "../components/common/PageTitle";
 import Nav from "../components/common/Nav";
 import MyLikeStoreCard from "../components/mylikestore/MyLikeStoreCard";
-import HttpClient from "../utils/api/customAxios";
 import PageNothing from "../components/common/PageNothing";
 import ModalDelete from "../components/common/ModalDelete";
 import ToastMessage from "../components/common/ToastMessage";
@@ -35,7 +37,7 @@ const MyLikeStore: React.FC = () => {
     await HttpClient.delete(`/my-page/like-cancel/${likeNo}`);
     setShowModalDelete(false);
     setShowToastMessage(true);
-    setTimeout(function () {
+    setTimeout(() => {
       window.location.reload();
     }, 1000);
   };

--- a/src/page/MyPage.tsx
+++ b/src/page/MyPage.tsx
@@ -53,7 +53,7 @@ const MyPage: React.FC = () => {
   const handlerMainPetEdit = async (petNo: number, petName: string) => {
     await HttpClient.put(`/KkoSoonNae/pet/main-pet/${petNo}`);
     setToastMessage(`대표 꼬순내가 ${petName}(으)로 변경되었습니다`);
-    setTimeout(function () {
+    setTimeout(() => {
       window.location.reload();
     }, 1000);
   };
@@ -107,7 +107,6 @@ const MyPage: React.FC = () => {
         }));
       })
     );
-    console.log(mypageInfos.myPet);
   }, []);
 
   var settings = {
@@ -208,12 +207,12 @@ const MyPage: React.FC = () => {
             <MyPagePetAdd userName={mypageInfos.userNickname} />
           )}
         </div>
-        <div className="flex flex-col justify-center items-start mt-7 gap-5">
-          <div className="flex justify-center items-center gap-5 w-full">
+        <div className="flex flex-col justify-center items-start mt-7 gap-3">
+          <div className="flex justify-center items-center gap-3 w-full">
             <MyPageMainBtn title="예약내역" link="/myreservation" />
             <MyPageMainBtn title="내가 쓴 리뷰" link="/myreview" />
           </div>
-          <div className="flex justify-center items-center gap-5 w-full">
+          <div className="flex justify-center items-center gap-3 w-full">
             <MyPageMainBtn title="관심매장" link="/mylikestore" />
             <MyPageMainBtn title="문의하기" link="/registerqna" />
           </div>

--- a/src/page/MyQnA.tsx
+++ b/src/page/MyQnA.tsx
@@ -1,14 +1,16 @@
+import HttpClient from "../utils/api/customAxios";
+
 import React, { useEffect, useState } from "react";
+import { format, parseISO } from "date-fns";
+import { ko } from "date-fns/locale";
+
+import PageNothing from "../components/common/PageNothing";
+import ModalDelete from "../components/common/ModalDelete";
+import ToastMessage from "../components/common/ToastMessage";
 import OuterLayout from "../components/common/OuterLayout";
 import PageTitle from "../components/common/PageTitle";
 import Nav from "../components/common/Nav";
 import MyQnACard from "../components/myqna/MyQnACard";
-import HttpClient from "../utils/api/customAxios";
-import { format, parseISO } from "date-fns";
-import { ko } from "date-fns/locale";
-import PageNothing from "../components/common/PageNothing";
-import ModalDelete from "../components/common/ModalDelete";
-import ToastMessage from "../components/common/ToastMessage";
 
 interface MyQnADatasType {
   status?: string;
@@ -34,7 +36,7 @@ const MyQnA: React.FC = () => {
     await HttpClient.delete(`/KkoSoonNae/qna/deleteQna/${qnaNo}`);
     setShowModalDelete(false);
     setShowToastMessage(true);
-    setTimeout(function () {
+    setTimeout(() => {
       window.location.reload();
     }, 1000);
   };

--- a/src/page/MyReservation.tsx
+++ b/src/page/MyReservation.tsx
@@ -1,15 +1,16 @@
 import HttpClient from "../utils/api/customAxios";
 
 import React, { useEffect, useState } from "react";
+import { format, parse, parseISO } from "date-fns";
+import { ko } from "date-fns/locale";
+
+import PageNothing from "../components/common/PageNothing";
+import ModalDelete from "../components/common/ModalDelete";
+import ToastMessage from "../components/common/ToastMessage";
 import OuterLayout from "../components/common/OuterLayout";
 import PageTitle from "../components/common/PageTitle";
 import Nav from "../components/common/Nav";
 import MyReservationCard from "../components/myreservation/MyReservationCard";
-import { format, parse, parseISO } from "date-fns";
-import { ko } from "date-fns/locale";
-import PageNothing from "../components/common/PageNothing";
-import ModalDelete from "../components/common/ModalDelete";
-import ToastMessage from "../components/common/ToastMessage";
 
 interface MyReservationDatasType {
   reservationNo: number;
@@ -39,7 +40,7 @@ const MyReservation: React.FC = () => {
     await HttpClient.delete(`/my-page/avail-cancel/${reservationNo}`);
     setShowModalDelete(false);
     setShowToastMessage(true);
-    setTimeout(function () {
+    setTimeout(() => {
       window.location.reload();
     }, 1000);
   };

--- a/src/page/MyReview.tsx
+++ b/src/page/MyReview.tsx
@@ -1,6 +1,7 @@
 import HttpClient from "../utils/api/customAxios";
 
 import React, { useEffect, useState } from "react";
+
 import OuterLayout from "../components/common/OuterLayout";
 import PageTitle from "../components/common/PageTitle";
 import Nav from "../components/common/Nav";
@@ -34,7 +35,7 @@ const MyReview: React.FC = () => {
     await HttpClient.delete(`/my-page/my-review/${reviewNo}`);
     setShowModalDelete(false);
     setShowToastMessage(true);
-    setTimeout(function () {
+    setTimeout(() => {
       window.location.reload();
     }, 1000);
   };

--- a/src/page/RegisterQnA.tsx
+++ b/src/page/RegisterQnA.tsx
@@ -1,10 +1,10 @@
-import React from "react";
+import React, { useState } from "react";
+
+import RegisterQnAForm from "../components/registerqna/RegisterQnAForm";
+import PageComplete from "../components/common/PageComplete";
 import OuterLayout from "../components/common/OuterLayout";
 import PageTitle from "../components/common/PageTitle";
 import Nav from "../components/common/Nav";
-import { useState } from "react";
-import RegisterQnAForm from "../components/registerqna/RegisterQnAForm";
-import PageComplete from "../components/common/PageComplete";
 
 const RegisterQnA: React.FC = () => {
   const [step, setStep] = useState(1);


### PR DESCRIPTION
1. 프로필 수정 중복확인 구현
  - 닉네임을 수정했지만 중복확인을 하지 않았을 때 => "닉네임 중복확인을 진행해주세요" 문구의 토스트 띄움
  - 중복된 닉네임으로 수정하기 버튼을 눌렀을 때 => "이미 사용 중인 닉네임으로 수정할 수 없습니다" 문구의 토스트 띄움
 - 현재 사용 중인 닉네임으로 중복확인을 할 경우 => "현재 사용 중인  닉네임입니다" 문구의 토스트를 띄움
2. 꼬순내 정보 수정/등록 폼 분기처리
  - 꼬순내 정보를 수정하지 않고 제출하려는 경우 => "반려 동물의 정보를 수정해주세요" 토스트를 띄움
  - 꼬순내 정보 등록 시 입력 값의 유효성이 완전하지 않을 경우에는 버튼이 회색으로 변하며, 제출 버튼을 눌렀을 때 "반려동물의 정보를 올바르게 작성해주세요" 토스트를 띄움
3. 코드 정리
 - import 정리
 - 불필요한 주석 정리
